### PR TITLE
chore(deps): upgrade react-router to 8 and drop react-router-dom

### DIFF
--- a/apps/shell/src/client/App.tsx
+++ b/apps/shell/src/client/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { FunctionComponent } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import 'src/client/styles/index.scss';
 

--- a/apps/shell/src/client/bootstrap.tsx
+++ b/apps/shell/src/client/bootstrap.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, Suspense } from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 import {
     HydrationBoundary,

--- a/apps/shell/src/client/pages/not-found/NotFound.tsx
+++ b/apps/shell/src/client/pages/not-found/NotFound.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { HttpStatus } from 'src/client/contexts/http';
 

--- a/apps/shell/src/server/template/Index.html.tsx
+++ b/apps/shell/src/server/template/Index.html.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, Suspense } from 'react';
-import { StaticRouter } from 'react-router-dom';
+import { StaticRouter } from 'react-router';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { productionDomain } from '@cohbrgr/env';

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "dependencies": {
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-router": "7.18.1",
-        "react-router-dom": "7.18.1"
+        "react-router": "8.3.0"
     },
     "devDependencies": {
         "@cohbrgr/prettier": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,8 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       react-router:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-router-dom:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@cohbrgr/prettier':
         specifier: workspace:*
@@ -3078,6 +3075,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -3085,10 +3085,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -4690,19 +4686,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -5014,9 +5003,6 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8701,11 +8687,11 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  cookie@1.1.1: {}
 
   core-js-compat@3.49.0:
     dependencies:
@@ -10371,17 +10357,10 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -10729,8 +10708,6 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
Upgrades react-router from 7.18.1 to 8.3.0 and drops the now-removed `react-router-dom`.

## What changed

react-router 8 consolidates everything into the single `react-router` package — `react-router-dom` no longer exists. The four import sites move accordingly:

| File | Import |
| --- | --- |
| `apps/shell/src/server/template/Index.html.tsx` | `StaticRouter` |
| `apps/shell/src/client/bootstrap.tsx` | `BrowserRouter` |
| `apps/shell/src/client/App.tsx` | `Route`, `Routes` |
| `apps/shell/src/client/pages/not-found/NotFound.tsx` | `Link` |

`react-router-dom` is removed from the dependency list. No API/behaviour changes were needed — the router usage (library-mode `Routes`/`Route`, SSR `StaticRouter`, client `BrowserRouter`, `Link`) is identical in v8.

React 19.2.8 satisfies the new `react-router` peer (`>=19.2.7`).

## Why now

- **Unblocked by the Jest → Vitest migration** — react-router 8 is ESM-only, which is why it was parked until the test layer stopped running in CommonJS.
- **Clears the one high-severity advisory that reached the shipped bundle** — the react-router RSC-mode CSRF bypass. This app is classic SSR and doesn't use RSC mode, so it wasn't exploitable here, but the bump resolves it regardless.

## Validation

- Build (9 projects), lint (9), unit tests (233) — all pass.
- Full Playwright e2e (21 passed, 2 visual skipped on non-Linux): specifically exercises routing — SSR render, **client-side navigation via `Link`** (404 → home), the 404 route, and the offline route.
